### PR TITLE
[BB-1780] Add custom completion option

### DIFF
--- a/html_xblock/static/js/html_completion.js
+++ b/html_xblock/static/js/html_completion.js
@@ -1,0 +1,23 @@
+function HTML5CompletionXBlock(runtime, element, data) {
+    /*
+    Add dummy #complete element with event listener for sending the POST to the custom `complete` handler.
+     */
+    // Add dummy element.
+    var main = document.getElementById("main");
+    var tracker = document.createElement("div");
+    tracker.id = "complete";
+    main.appendChild(tracker);
+
+    // Add `complete` handler to the dummy element.
+    tracker.addEventListener("click", function () {
+        var handlerUrl = runtime.handlerUrl(element, 'complete');
+
+        $.post(handlerUrl, JSON.stringify(data)).done(function (response) {
+            if (response.result === 'success') {
+                runtime.notify('save', {state: 'end'});
+            } else {
+                runtime.notify('error', {msg: response.message})
+            }
+        });
+    });
+}

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -27,6 +27,8 @@ class TestHTMLXBlock(unittest.TestCase):
         self.assertEqual(block.allow_javascript, False)
         fragment = block.student_view()
         self.assertIn('<div>Safe <b>html</b></div>', fragment.content)
+        self.assertFalse(fragment.js_init_fn)
+        self.assertNotIn('var tracker', fragment.foot_html())
 
     def test_render_with_unsafe(self):
         """
@@ -55,3 +57,19 @@ class TestHTMLXBlock(unittest.TestCase):
         self.assertEqual(block.allow_javascript, True)
         fragment = block.student_view()
         self.assertIn('<div>Safe <b>html</b><script>alert(\'javascript\');</script></div>', fragment.content)
+
+    def test_render_with_completion(self):
+        """
+        Test a basic rendering with custom completion enabled.
+        Expects that `HTML5CompletionXBlock` JS function was initialized and `tracker` is present in the resources.
+        """
+        field_data = DictFieldData({
+            'data': '<main></main>',
+            'allow_javascript': True,
+            'has_custom_completion': True
+        })
+        block = html_xblock.HTML5XBlock(self.runtime, field_data, None)
+        self.assertEqual(block.has_custom_completion, True)
+        fragment = block.student_view()
+        self.assertIn('HTML5CompletionXBlock', fragment.js_init_fn)
+        self.assertIn('var tracker', fragment.foot_html())


### PR DESCRIPTION
This adds an option to disable automatic `publish_completion` event and enable custom `complete` endpoint that uses `emit_completion` from `CompletableXBlockMixin`.

Example use-case: we have a Wistia block and we want to add a custom completion even when the user has the certain amount of the video watched. To do this, we can embed the following script in the HTML XBlock:
   ```html
   <script>
   // Wait for the page to load.
   window.addEventListener('load', function () {
     window._wq = window._wq || [];
       _wq.push({ "_all": function(video) {
         video.bind('percentwatchedchanged', function (percent, lastPercent) {
           if (percent >= .25 && lastPercent < .25) {
             console.log('The viewer has watched 25% of the video!')
             document.getElementById('complete').click(); // Trigger `emit_completion`.
           }
         });
     }});
   });
   </script>
   ```
# Testing instructions:
1. Go to http://localhost:18000/admin/waffle/switch/ and set `completion.enable_completion_tracking` as `active`.
1. Install this version of `xblock-html` (`make lms/studio-shell`, `pip install -e /edx/src/xblock-html/`, `make lms-restart && make studio-restart`).
1. Enable `html5` in advanced settings of a course.
1. Create `Advanced -> Text` component.
1. In the new block's settings set `Editor = Raw` and `Allow JavaScript execution = True` and save.
1. In the Editor paste the following:
   ```html
      <p><strong>This is just a simple test.</strong></p>
      <script>
         // Wait for the page to fully load.
         window.addEventListener('load', function () {
            document.getElementById('complete').click();
         });
      </script>
   ```
1. Publish the block and visit it int the LMS.
1. Confirm that the `publish_completion` event is triggered as it was before (if it doesn't, do the next step and go back to this one).
1. Go to the Django shell (`make lms-shell`, `/edx/bin/edxapp-shell-lms`) and type:
   ```python
     from completion.models import BlockCompletion
     BlockCompletion.objects.all()
     BlockCompletion.objects.all().delete()
   ```
1. In the block's settings set `Use custom completion = True` and publish it.
1. Check that the `complete` POST is sent and completion appears in Django shell (and in the UI after refreshing the page).
1. (Optional) Remove the `click` from the HTML block's content and see that the `complete` request is no longer POSTed.