### PR TITLE
[BB-1780] Substitute keywords

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,6 +7,7 @@ lazy==1.1
 pytest-cov==2.6.0
 tox==3.1.3
 tox-battery==0.5.1
+mock==3.0.5
 
 # Github requirements
 git+https://github.com/edx/django-pyfs.git@1.0.3#egg=django-pyfs==1.0.3

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 setup(
     name='html-xblock',
-    version='0.1',
+    version='0.1.1',
     description='HTML XBlock will help creating and using a secure and easy-to-use HTML blocks',
     license='AGPL v3',
     packages=[


### PR DESCRIPTION
This adds replacing `%%USER_ID%%` and `%%COURSE_ID%%` keywords with, respectively, anonymous user ID and course [HTML ID](https://github.com/edx/opaque-keys/blob/master/opaque_keys/edx/locator.py#L283-L291).
This is performed in the "old" `HtmlBlock` [this](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/html_module.py#L120-L121) way.

# Testing instructions:
1. Install this version of `xblock-html` (`make lms/studio-shell`, `pip install -e /edx/src/xblock-html/`, `make lms-restart && make studio-restart`).
1. Enable `html5` in advanced settings of a course.
1. Create `Advanced -> Text` component.
1. In the new block's settings set `Editor = Raw` and `Allow JavaScript execution = True` and save.
1. In the Editor paste the following:
   ```html
	<p><strong>This is just a simple test.</strong></p>
	<p id="UID" style="display:none">%%USER_ID%%</p>
	<p id="CID" style="display:none">%%COURSE_ID%%</p>
	<script>
	  var userId = document.getElementById("UID").innerHTML;
	  var courseId = document.getElementById("CID").innerHTML;
	  console.log("Logging userId...");
	  console.log(userId);
	  console.log("Logging courseId...");
	  console.log(courseId);
	</script>
   ```
1. Open browser's console and check that the logs contain proper user ID and course ID.