### PR TITLE
[BB-2120] Create excluded HTML5 block

### DIFF
--- a/html_xblock/__init__.py
+++ b/html_xblock/__init__.py
@@ -1,2 +1,2 @@
 """HTML XBlock module"""
-from .html import HTML5XBlock
+from .html import ExcludedHTML5XBlock, HTML5XBlock

--- a/html_xblock/html.py
+++ b/html_xblock/html.py
@@ -3,6 +3,7 @@
 import logging
 
 import pkg_resources
+from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Boolean, Scope, String
 from xblock.fragment import Fragment
@@ -255,3 +256,18 @@ class HTML5XBlock(StudioEditableXBlockMixin, XBlock):
                 fields.append(field_info)
 
         return fields
+
+
+class ExcludedHTML5XBlock(HTML5XBlock):
+    """
+    This XBlock is excluded from the completion calculations.
+    """
+
+    display_name = String(
+        display_name=_('Display Name'),
+        help=_('The display name for this component.'),
+        scope=Scope.settings,
+        default=_('Exclusion')
+    )
+    has_custom_completion = True
+    completion_mode = XBlockCompletionMode.EXCLUDED

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     entry_points={
         'xblock.v1': [
             'html5 = html_xblock:HTML5XBlock',
+            'excluded_html5 = html_xblock:ExcludedHTML5XBlock',
         ]
     },
     package_data=package_data("html_xblock", ["static", "public"]),

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 setup(
     name='html-xblock',
-    version='0.1.1',
+    version='0.1.2',
     description='HTML XBlock will help creating and using a secure and easy-to-use HTML blocks',
     license='AGPL v3',
     packages=[


### PR DESCRIPTION
This MR adds block that does not need to be in the user's viewport to have the unit marked as completed.

1. Go to http://localhost:18000/admin/waffle/switch/ and set `completion.enable_completion_tracking` as `active`.
1. Install [this branch](https://github.com/open-craft/completion/tree/agrendalath/bb-2120-ignore_excluded_xblocks)
1. Checkout `edx-platform` to version from the ticket.
1. Install this version of `xblock-html` (`make lms/studio-shell`, `pip install -e /edx/src/xblock-html`, `make lms-restart && make studio-restart`).
1. Add `excluded_html5` to the course.
1. Create a new unit with standard HTML block and `Exclusion` block. The content of the latter should be larger than the workspace of the screen (e.g. generate 50 paragraphs of [Lorem ipsum](https://lipsum.com/feed/html)).
1. Open the main course view and see that the unit is not marked as completed.
1. Open the unit for at least three seconds (you can observe `publish_completion` request being sent in browser's `Network` tab).
1. Refresh the page and check that there is a checkmark on the navigation bar and on the course's main view.