### PR TITLE
[BB-4011] Koa upgrade: bump Python version for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &DEFAULT
   working_directory: /home/circleci/xblock-html
   docker:
-    - image: circleci/python:3.5
+    - image: circleci/python:3.8
 
 
 version: 2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install https://github.com/open-craft/xblock-html
 ```
 You may specify the `-e` flag if you intend to develop on the repo.
 
-Note that as of version 1.0.0, Python 2.7 is no longer supported. The current minimum Python version is 3.5.
+Note that as of version 1.0.0, Python 2.7 is no longer supported. The current minimum Python version is 3.8.
 
 To enable this block, add `"html5"` and `"excluded_html5"` to the course's advanced module list. The options `Text` and `Exclusion` will appear in the advanced components.
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 setup(
     name='html-xblock',
-    version='1.0.0',
+    version='1.1.0',
     description='HTML XBlock will help creating and using a secure and easy-to-use HTML blocks',
     license='AGPL v3',
     packages=[


### PR DESCRIPTION
The Koa release uses Python 3.8, so we should be using this Python version for the CI from now on.

### Testing instructions
1. Check that the CI is passing.