### PR TITLE
fix: html tables rendering for subclasses of HTML5XBlock in studio preview

### DIFF
--- a/html_xblock/static/css/html_preview.css
+++ b/html_xblock/static/css/html_preview.css
@@ -7,71 +7,71 @@
 
 /* fall back to default browser styles for all rows; the inline styles (like
  * border style and color) would overwrite it */
-.studio-xblock-wrapper [data-block-type="html5"] table > * > tr {
+.studio-xblock-wrapper .html5_xblock table > * > tr {
   border: unset;
 }
 
 /* fall back to default browser styles, if border attribute is not set; the
  * inline styles (like border style and color) would overwrite it */
-.studio-xblock-wrapper [data-block-type="html5"] table:not([border]) {
+.studio-xblock-wrapper .html5_xblock table:not([border]) {
   border: unset;
 }
 
 /* default styles for any table that had border attribute set; the inline
  * styles (like border style and color) would overwrite it */
-.studio-xblock-wrapper [data-block-type="html5"] table[border] {
+.studio-xblock-wrapper .html5_xblock table[border] {
   border: 1px solid black;
 }
 
 /* change the border width, depending on the explicit value of the border
  * attribute */
-.studio-xblock-wrapper [data-block-type="html5"] table[border="1"] {
+.studio-xblock-wrapper .html5_xblock table[border="1"] {
   border-width: 1px;
 }
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border="2"] {
+.studio-xblock-wrapper .html5_xblock table[border="2"] {
   border-width: 2px;
 }
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border="3"] {
+.studio-xblock-wrapper .html5_xblock table[border="3"] {
   border-width: 3px;
 }
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border="4"] {
+.studio-xblock-wrapper .html5_xblock table[border="4"] {
   border-width: 4px;
 }
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border="5"] {
+.studio-xblock-wrapper .html5_xblock table[border="5"] {
   border-width: 5px;
 }
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border="6"] {
+.studio-xblock-wrapper .html5_xblock table[border="6"] {
   border-width: 6px;
 }
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border="7"] {
+.studio-xblock-wrapper .html5_xblock table[border="7"] {
   border-width: 7px;
 }
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border="8"] {
+.studio-xblock-wrapper .html5_xblock table[border="8"] {
   border-width: 8px;
 }
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border="9"] {
+.studio-xblock-wrapper .html5_xblock table[border="9"] {
   border-width: 9px;
 }
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border="10"] {
+.studio-xblock-wrapper .html5_xblock table[border="10"] {
   border-width: 10px;
 }
 /* etc until the value we think is reasonable */
 
-.studio-xblock-wrapper [data-block-type="html5"] table[border] > * > tr > td,
-.studio-xblock-wrapper [data-block-type="html5"] table[border] > * > tr > th,
-.studio-xblock-wrapper [data-block-type="html5"] table[border] > * > td,
-.studio-xblock-wrapper [data-block-type="html5"] table[border] > * > th,
-.studio-xblock-wrapper [data-block-type="html5"] table[border] > td,
-.studio-xblock-wrapper [data-block-type="html5"] table[border] > th {
+.studio-xblock-wrapper .html5_xblock table[border] > * > tr > td,
+.studio-xblock-wrapper .html5_xblock table[border] > * > tr > th,
+.studio-xblock-wrapper .html5_xblock table[border] > * > td,
+.studio-xblock-wrapper .html5_xblock table[border] > * > th,
+.studio-xblock-wrapper .html5_xblock table[border] > td,
+.studio-xblock-wrapper .html5_xblock table[border] > th {
   border-width: thin;
   border-style: inset;
 }

--- a/html_xblock/static/html/lms.html
+++ b/html_xblock/static/html/lms.html
@@ -1,1 +1,1 @@
-<div>{{ self.html | safe }}</div>
+<div class="html5_xblock">{{ self.html | safe }}</div>

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 setup(
     name='html-xblock',
-    version='1.2.1',
+    version='1.2.2',
     description='HTML XBlock will help creating and using a secure and easy-to-use HTML blocks',
     license='AGPL v3',
     packages=[

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -53,7 +53,7 @@ class TestHTMLXBlock(unittest.TestCase):
         block = html_xblock.HTML5XBlock(self.runtime, field_data, None)
         self.assertEqual(block.allow_javascript, False)
         fragment = block.student_view()
-        self.assertIn('<div>Safe <b>html</b></div>', fragment.content)
+        self.assertIn('Safe <b>html</b>', fragment.content)
 
     def test_render_with_unsafe(self):
         """
@@ -65,7 +65,7 @@ class TestHTMLXBlock(unittest.TestCase):
         self.assertEqual(block.allow_javascript, False)
         fragment = block.student_view()
         self.assertIn(
-            '<div>Safe <b>html</b>&lt;script&gt;alert(\'javascript\');&lt;/script&gt;</div>',
+            'Safe <b>html</b>&lt;script&gt;alert(\'javascript\');&lt;/script&gt;',
             fragment.content
         )
 
@@ -91,7 +91,7 @@ class TestHTMLXBlock(unittest.TestCase):
         block = html_xblock.HTML5XBlock(self.runtime, field_data, None)
         self.assertEqual(block.allow_javascript, True)
         fragment = block.student_view()
-        self.assertIn('<div>Safe <b>html</b><script>alert(\'javascript\');</script></div>', fragment.content)
+        self.assertIn('Safe <b>html</b><script>alert(\'javascript\');</script>', fragment.content)
 
     def test_substitution_no_system(self):
         """
@@ -100,7 +100,7 @@ class TestHTMLXBlock(unittest.TestCase):
         field_data = DictFieldData({'data': 'Safe <b>%%USER_ID%% %%COURSE_ID%%</b>'})
         block = html_xblock.HTML5XBlock(self.runtime, field_data, None)
         fragment = block.student_view()
-        self.assertIn('<div>Safe <b>%%USER_ID%% %%COURSE_ID%%</b></div>', fragment.content)
+        self.assertIn('Safe <b>%%USER_ID%% %%COURSE_ID%%</b>', fragment.content)
 
     def test_substitution_not_found(self):
         """
@@ -110,7 +110,7 @@ class TestHTMLXBlock(unittest.TestCase):
         block = html_xblock.HTML5XBlock(self.runtime, field_data, None)
         block.system = Mock(anonymous_student_id=None)
         fragment = block.student_view()
-        self.assertIn('<div>Safe <b>%%USER_ID%% %%COURSE_ID%%</b></div>', fragment.content)
+        self.assertIn('Safe <b>%%USER_ID%% %%COURSE_ID%%</b>', fragment.content)
 
     def test_user_id_substitution(self):
         """
@@ -120,7 +120,7 @@ class TestHTMLXBlock(unittest.TestCase):
         block = html_xblock.HTML5XBlock(self.runtime, field_data, None)
         block.system = Mock(anonymous_student_id='test_user')
         fragment = block.student_view()
-        self.assertIn('<div>Safe <b>test_user</b></div>', fragment.content)
+        self.assertIn('Safe <b>test_user</b>', fragment.content)
 
     def test_course_id_substitution(self):
         """
@@ -132,4 +132,4 @@ class TestHTMLXBlock(unittest.TestCase):
         course_locator_mock.html_id = Mock(return_value='test_course')
         block.system = Mock(course_id=course_locator_mock)
         fragment = block.student_view()
-        self.assertIn('<div>Safe <b>test_course</b></div>', fragment.content)
+        self.assertIn('Safe <b>test_course</b>', fragment.content)


### PR DESCRIPTION
### Description

This PR is a follow up fix to #18. Previous changes fixed rendering of the html tables in studio preview for `HTML5XBlock`. This PR changes the fix to work for subclasses of `HTML5XBlock`, like `ExcludedHTML5XBlock` and `CompletableHTML5XBlock`.

#### Screenshots
HTML used for screenshots:
```html
<table style="border-collapse: collapse; width: 100%; height: 46px;" border="1">
<tbody>
<tr style="height: 18px;">
<td style="width: 15.4861%; height: 18px; background-color: #c2e0f4; border: 3px solid #000000;"><strong>Column 1</strong></td>
<td style="width: 21.4427%; height: 18px; background-color: #c2e0f4; border: 3px solid #000000;"><strong>Column 2</strong></td>
<td style="width: 26.8784%; background-color: #c2e0f4; height: 18px; border: 3px solid #000000;"><strong>Column 3</strong></td>
<td style="width: 35.1816%; height: 18px; background-color: #c2e0f4; border: 3px solid #000000;"><strong>Column 4</strong></td>
</tr>
<tr style="height: 18px;">
<td style="width: 15.4861%; height: 18px; background-color: #fbeeb8;">A2</td>
<td style="width: 21.4427%; height: 18px; background-color: #fbeeb8;">B2</td>
<td style="width: 26.8784%; height: 18px; background-color: #fbeeb8;">C2</td>
<td style="width: 35.1816%; height: 18px; background-color: #fbeeb8;">D2</td>
</tr>
<tr style="height: 10px;">
<td style="width: 15.4861%; height: 10px; background-color: #fbeeb8;">A3</td>
<td style="width: 21.4427%; height: 10px; background-color: #fbeeb8;">B3</td>
<td style="width: 26.8784%; height: 10px; background-color: #fbeeb8;">C3</td>
<td style="width: 35.1816%; height: 10px; background-color: #fbeeb8;">D3</td>
</tr>
<tr style="height: 0px;">
<td style="width: 15.4861%; height: 0px; background-color: #fbeeb8;">A4</td>
<td style="width: 21.4427%; height: 0px; background-color: #fbeeb8;">B4</td>
<td style="width: 26.8784%; height: 0px; background-color: #fbeeb8;">C4</td>
<td style="width: 35.1816%; height: 0px; background-color: #fbeeb8;">D4</td>
</tr>
</tbody>
</table>
```
##### Before
![image](https://user-images.githubusercontent.com/30300520/196912025-c11eecaf-098f-42d0-b14e-d2d47a1673fe.png)
##### After
![image](https://user-images.githubusercontent.com/30300520/196911506-ee1b4686-1fdf-410b-8795-892916961b7f.png)

### Testing instructions
1. Setup devstack (for development Maple was used, but Nutmeg or master should also work)
1. Clone `xblock-html` repo into `<devstack-root>/src/` and change the branch
1. Clone `xblock-html-completable` repo into `<devstack-root>/src/`
1. Start `lms`, `studio`, and `learning` MFE:
   ```bash
    make lms-up studio-up frontend-app-learning-up
   ```
1. Install `xblock-html` and `xblock-html-completable` into `studio`:
    ```bash
    make studio-shell studio-restart
    pip install -e /edx/src/xblock-html/ /edx/src/xblock-html-completable/ && exit
    ```
1. Login into studio as staff (e.g. `edx@example.com`)
1. Go to demo course advanced settings, and add `html5`, `excluded_html5` and `completable_html5` in `Advanced Module List`
1. Go to demo course outline, and create a new section, subsection and unit
1. In the new unit add `html5` xblock - Advanced > Text
1. In the new unit add `excluded_html5` xblock - Advanced > Exclusion
1. In the new unit add `completable_html5` xblock - Advanced > Completable
1. Create a new table using the visual editor in each XBlock
1. Check that the fix works for all XBlocks, i.e. tables in all three XBlocks have borders


`Private-ref`: [BB-6822](https://tasks.opencraft.com/browse/BB-6822)