### PR TITLE
refactor: adjust sanitizing and style rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,22 +41,6 @@ jobs:
           name: Running tests
           command: make unit-coverage
 
-  test_nutmeg:
-    <<: *DEFAULT
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Activate virtualenv
-          command: echo 'source /tmp/workspace/env/bin/activate' >> $BASH_ENV
-      - run:
-          name: Install bleach 5
-          command: pip install bleach[css]==5.0.0
-      - run:
-          name: Running tests
-          command: make unit-coverage
-
   quality:
     <<: *DEFAULT
     steps:
@@ -66,22 +50,6 @@ jobs:
       - run:
           name: Activate virtualenv
           command: echo 'source /tmp/workspace/env/bin/activate' >> $BASH_ENV
-      - run:
-          name: Test Quality
-          command: make quality
-
-  quality_nutmeg:
-    <<: *DEFAULT
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Activate virtualenv
-          command: echo 'source /tmp/workspace/env/bin/activate' >> $BASH_ENV
-      - run:
-          name: Install bleach 5
-          command: pip install bleach[css]==5.0.0
       - run:
           name: Test Quality
           command: make quality
@@ -97,11 +65,3 @@ workflows:
       - quality:
           requires:
             -  build
-      - test_nutmeg:
-          requires:
-            - test
-            - quality
-      - quality_nutmeg:
-          requires:
-            - test
-            - quality

--- a/html_xblock/bleaching.py
+++ b/html_xblock/bleaching.py
@@ -2,16 +2,7 @@
 A new HTML XBlock that is designed with security and embedding in mind.
 """
 import bleach
-
-try:
-    from bleach.css_sanitizer import CSSSanitizer
-except (ImportError, ModuleNotFoundError):
-    # NOTE:
-    # The bleach library changes the way CSS Styles are cleaned in
-    # version 5.0.0. Since the edx-platform uses version 4.1.0 in
-    # Maple, this import is handled within a try block.
-    # This try block CAN BE REMOVED for Nutmeg
-    CSSSanitizer = None
+from bleach.css_sanitizer import CSSSanitizer
 
 
 class SanitizedText:  # pylint: disable=too-few-public-methods
@@ -40,26 +31,14 @@ class SanitizedText:  # pylint: disable=too-few-public-methods
         It does so by redefining the safe values we're currently using and
         considering safe in the platform.
         """
-        if CSSSanitizer:
-            # pylint: disable-next=unexpected-keyword-arg
-            cleaner = bleach.Cleaner(
-                tags=self._get_allowed_tags(),
-                attributes=self._get_allowed_attributes(),
-                css_sanitizer=CSSSanitizer(
-                    allowed_css_properties=self._get_allowed_styles()
-                )
+        # pylint: disable-next=unexpected-keyword-arg
+        cleaner = bleach.Cleaner(
+            tags=self._get_allowed_tags(),
+            attributes=self._get_allowed_attributes(),
+            css_sanitizer=CSSSanitizer(
+                allowed_css_properties=self._get_allowed_styles()
             )
-        else:
-            # NOTE: This is maintaining backward compatibility with bleach 4.1.0
-            # used in Maple release of edx-platform. This can be removed
-            # for Nutmeg release which uses bleach 5.0.0
-            # pylint: disable-next=unexpected-keyword-arg
-            cleaner = bleach.Cleaner(
-                tags=self._get_allowed_tags(),
-                attributes=self._get_allowed_attributes(),
-                styles=self._get_allowed_styles()
-            )
-
+        )
         return cleaner
 
     def _get_allowed_tags(self):

--- a/html_xblock/html.py
+++ b/html_xblock/html.py
@@ -229,24 +229,14 @@ class HTML5XBlock(StudioEditableXBlockMixin, XBlock):
         return data
 
     @property
-    def sanitized_html(self):
-        """
-        A property that returns a sanitized text field of the existing data object.
-        """
-        data = self.substitute_keywords()
-        html = SanitizedText(data)
-        return html.value
-
-    @property
     def html(self):
         """
         A property that returns this module content data, according to `allow_javascript`.
         I.E: Sanitized data if it's true or plain data if it's false.
         """
-        if self.allow_javascript:
-            data = self.substitute_keywords()
-            return data
-        return self.sanitized_html
+        data = self.substitute_keywords()
+        html = SanitizedText(data, allow_javascript=self.allow_javascript)
+        return html
 
     def get_editable_fields(self):
         """

--- a/html_xblock/static/html/lms.html
+++ b/html_xblock/static/html/lms.html
@@ -1,1 +1,1 @@
-<div class="html5_xblock">{{ self.html | safe }}</div>
+<div class="html5_xblock xmodule_display xmodule_HtmlBlock">{{ self.html | safe }}</div>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,5 @@
 
 xblock-utils==2.2.0
 edx-i18n-tools==0.9.1
-bleach==4.1.0  # version pinned for Maple
-# bleach[css]==5.0.0  # Use this for Nutmeg
+bleach[css]==5.0.0
 django==3.2.13

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 setup(
     name='html-xblock',
-    version='1.2.2',
+    version='1.3.0',
     description='HTML XBlock will help creating and using a secure and easy-to-use HTML blocks',
     license='AGPL v3',
     packages=[


### PR DESCRIPTION
**Description**

Updates allowed_tags, allowed_attributes and allowed_styles rules for sanitizing tags in html. **This MR also removes maple support**

**Test instructions:**

1. Install this xblock using [instructions](https://github.com/open-craft/xblock-html#installation) provided in readme.
2. Create a `Text` and `Exclusion` block from advanced components.
3. Set below html as raw html in the block
```html
<p>Exclusion block</p>
--
 
<h1>H1</h1>
<h2>H2</h2>
<h3>H3</h3>
<h4>H4</h4>
<h5>H5</h5>
<h6>H6</h6>
<p>Paragraph: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
<p>quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. <a href="">Excepteur sint</a> occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
<img src="https://onlinelearning.hms.harvard.edu/asset-v1:HMX+DSBX+2021_07+type@asset+block@design_sandbox_card.png" alt="card" />
 
<blockquote>This is a blockquote</blockquote>
<p><em>emphasis</em><br>
<strong>strong</strong><br>
<b>bold</b><br>
<i>italics</i></p>
<ul>
<li>unordered list item</li>
<li>unordered list item</li>
</ul>
<ol>
<li>ordered list item</li>
<li>ordered list item</li>
</ol>
```
4. Save and check preview
5. Create one more block by using component under `Text` -> `Raw HTML` and paste the same content.
6. Some elements will be not be rendered properly by the advanced components.
7. Now checkout this MR and restart LMS/CMS service
8. Now compare preview with the default block, it should be similar in design.
9. Test `allow_javascript` option in settings by adding a script tag at the end as below:
```html
<script>alert("hello")</script>
```

![image](https://user-images.githubusercontent.com/10894099/215069437-304149e4-c973-43e8-be8b-28c9c44d3df0.png)
