### PR TITLE
feat: allow using `details` and `summary` HTML tags

### DIFF
--- a/html_xblock/__init__.py
+++ b/html_xblock/__init__.py
@@ -1,4 +1,4 @@
 """HTML XBlock module."""
 from .html import ExcludedHTML5XBlock, HTML5XBlock
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"

--- a/html_xblock/bleaching.py
+++ b/html_xblock/bleaching.py
@@ -80,6 +80,8 @@ class SanitizedText:
             'u',
             'style',
             'iframe',
+            'details',
+            'summary',
         }
 
         if self.allow_javascript:


### PR DESCRIPTION
## Description
Allows the usage of `details` and `summary` HTML tags.

## Supporting information

BB-8726

## Testing instructions

Create an Xblock and add the following HTML code 
```
<details class="custom-accordion"> <summary> Conflicts of interest</summary> 
Some details. And then some more.
</details>
```
The HTML tags are escaped.

When using this PR's branch instead, the tags are taken into account.
